### PR TITLE
Fix integration with system menu in macOS

### DIFF
--- a/core/src/main/java/com/github/weisj/darklaf/DarkLaf.java
+++ b/core/src/main/java/com/github/weisj/darklaf/DarkLaf.java
@@ -105,7 +105,6 @@ public class DarkLaf extends BasicLookAndFeel implements PropertyChangeListener 
             loadThemeDefaults(defaults);
             initIdeaDefaults(defaults);
             patchComboBox(metalDefaults, defaults);
-            adjustPlatformSpecifics(defaults);
 
             JFrame.setDefaultLookAndFeelDecorated(true);
             JDialog.setDefaultLookAndFeelDecorated(true);
@@ -117,15 +116,13 @@ public class DarkLaf extends BasicLookAndFeel implements PropertyChangeListener 
         return super.getDefaults();
     }
 
-    protected void adjustPlatformSpecifics(final UIDefaults defaults) {
-        boolean useScreenMenuBar = "true".equalsIgnoreCase(System.getProperty("apple.laf.useScreenMenuBar",
-                                                                              "false"));
-        if (SystemInfo.isMac && !useScreenMenuBar) {
-            defaults.put("MenuBarUI", "com.github.weisj.darklaf.ui.menu.DarkMenuBarUI");
-            defaults.put("MenuUI", "com.github.weisj.darklaf.ui.menu.DarkMenuUI");
-        } else {
-            defaults.remove("MenuBarUI");
-            defaults.remove("MenuUI");
+    protected void adjustPlatformSpecifics(final Properties uiProps) {
+        boolean useScreenMenuBar = Boolean.getBoolean("apple.laf.useScreenMenuBar");
+        // If user wants to use Apple menu bar, then we need to keep the default
+        // component for MenuBarUI and MenuUI
+        if (SystemInfo.isMac && useScreenMenuBar) {
+            uiProps.remove("MenuBarUI");
+            uiProps.remove("MenuUI");
         }
     }
 
@@ -182,6 +179,7 @@ public class DarkLaf extends BasicLookAndFeel implements PropertyChangeListener 
         currentTheme.loadUIProperties(uiProps, defaults);
         currentTheme.loadIconProperties(uiProps, defaults);
         currentTheme.loadPlatformProperties(uiProps, defaults);
+        adjustPlatformSpecifics(uiProps);
         defaults.putAll(uiProps);
 
         StyleSheet styleSheet = currentTheme.loadStyleSheet();


### PR DESCRIPTION
Note: removal of the components from `UIDefaults defaults` does not work, and it fails as follows:

```
UIDefaults.getUI() failed: no ComponentUI class for: javax.swing.JMenu[,0,0,0x0,invalid,alignmentX=0.0,alignmentY=0.0,border=,flags=0,maximumSize=,minimumSize=,preferredSize=,defaultIcon=,disabledIcon=,disabledSelectedIcon=,margin=null,paintBorder=false,paintFocus=false,pressedIcon=,rolloverEnabled=false,rolloverIcon=,rolloverSelectedIcon=,selectedIcon=,text=Non-Test Elements]
java.lang.Error
        at javax.swing.UIDefaults.getUIError(UIDefaults.java:731)
        at javax.swing.MultiUIDefaults.getUIError(MultiUIDefaults.java:130)
        at javax.swing.UIDefaults.getUI(UIDefaults.java:761)
        at javax.swing.UIManager.getUI(UIManager.java:1016)
        at javax.swing.JMenu.updateUI(JMenu.java:217)
        at javax.swing.JMenuItem.init(JMenuItem.java:212)
        at javax.swing.JMenuItem.<init>(JMenuItem.java:151)
        at javax.swing.JMenuItem.<init>(JMenuItem.java:128)
        at javax.swing.JMenu.<init>(JMenu.java:169)
        at org.apache.jmeter.gui.util.MenuFactory.makeMenu(MenuFactory.java:437)
        at org.apache.jmeter.gui.util.MenuFactory.makeMenu(MenuFactory.java:419)
        at org.apache.jmeter.control.gui.TestPlanGui.createPopupMenu(TestPlanGui.java:103)
        at org.apache.jmeter.gui.tree.JMeterTreeNode.createPopupMenu(JMeterTreeNode.java:184)
        at org.apache.jmeter.gui.action.EditCommand.doAction(EditCommand.java:45)
        at org.apache.jmeter.gui.action.ActionRouter.performAction(ActionRouter.java:87)
        at org.apache.jmeter.gui.action.ActionRouter.lambda$actionPerformed$0(ActionRouter.java:69)
        at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
```

This PR kills the property before it overrides defaults.

<img width="713" alt="jmeter_menu" src="https://user-images.githubusercontent.com/213894/74613702-94c60f00-5121-11ea-9a98-359a3f72f599.png">
