### PR TITLE
Reduce verbosity of Loading icon logging messages

### DIFF
--- a/core/src/main/java/com/github/weisj/darklaf/LafManager.java
+++ b/core/src/main/java/com/github/weisj/darklaf/LafManager.java
@@ -65,10 +65,10 @@ public final class LafManager {
             try (InputStream inputStream = DarkLaf.class.getClassLoader()
                                                         .getResourceAsStream("com/github/weisj/darklaf/log/logging.properties")) {
                 if (inputStream != null) {
-                    Logger.getGlobal().info("Loading logging configuration.");
+                    Logger.getGlobal().fine("Loading logging configuration.");
                     LogManager.getLogManager().readConfiguration(inputStream);
                 }
-                Logger.getGlobal().info("Loaded logging config" + LogManager.getLogManager().toString());
+                Logger.getGlobal().fine(() -> "Loaded logging config" + LogManager.getLogManager().toString());
             } catch (IOException e) {
                 Logger.getGlobal().log(Level.SEVERE, "init logging system", e);
             }

--- a/core/src/main/java/com/github/weisj/darklaf/icons/DarkSVGIcon.java
+++ b/core/src/main/java/com/github/weisj/darklaf/icons/DarkSVGIcon.java
@@ -87,7 +87,7 @@ public class DarkSVGIcon implements Icon, Serializable {
 
     private void ensureLoaded() {
         if (!loaded.get()) {
-            LOGGER.info("Loading icon '" + uri.toASCIIString() + "'.");
+            LOGGER.fine(() -> "Loading icon '" + uri.toASCIIString() + "'.");
             icon.setSvgURI(uri);
             loaded.set(true);
         }

--- a/core/src/main/java/com/github/weisj/darklaf/icons/LazyIcon.java
+++ b/core/src/main/java/com/github/weisj/darklaf/icons/LazyIcon.java
@@ -55,7 +55,7 @@ public abstract class LazyIcon implements Icon, UIResource {
 
     private void ensureLoaded() {
         if (!loaded) {
-            LOGGER.info("Loading icon '" + path + "'. Resolving from " + parentClass);
+            LOGGER.fine(() -> "Loading icon '" + path + "'. Resolving from " + parentClass);
             icon = loadIcon();
             loaded = true;
             if (icon == null) {


### PR DESCRIPTION
The following messages do not seem to be useful for the end-users, so I suggest to reduce the verbosity:

```
фев 17, 2020 10:16:36 AM com.github.weisj.darklaf.LafManager enableLogging
INFO: Loading logging configuration.
фев 17, 2020 10:16:36 AM com.github.weisj.darklaf.LafManager enableLogging
INFO: Loaded logging configjava.util.logging.LogManager@302552ec
фев 17, 2020 10:16:38 AM com.github.weisj.darklaf.icons.DarkSVGIcon ensureLoaded
INFO: Loading icon 'jar:file:/.../jmeter/lib/ext/darklaf-core.jar!/com/github/weisj/darklaf/icons/navigation/horizontalGlue.svg'.
фев 17, 2020 10:16:40 AM com.github.weisj.darklaf.icons.DarkSVGIcon ensureLoaded
INFO: Loading icon 'jar:file:/.../jmeter/lib/ext/darklaf-core.jar!/com/github/weisj/darklaf/icons/control/checkBox.svg'.
фев 17, 2020 10:16:40 AM com.github.weisj.darklaf.icons.DarkSVGIcon ensureLoaded
INFO: Loading icon 'jar:file:/.../jmeter/lib/ext/darklaf-core.jar!/com/github/weisj/darklaf/icons/control/checkBoxSelected.svg'.
фев 17, 2020 10:16:45 AM com.github.weisj.darklaf.icons.DarkSVGIcon ensureLoaded
INFO: Loading icon 'jar:file:/Users/vladimirsitnikov/Documents/code/jmeter/lib/ext/darklaf-core.jar!/com/github/weisj/darklaf/icons/navigation/arrowRight.svg'.
фев 17, 2020 10:16:47 AM com.github.weisj.darklaf.icons.DarkSVGIcon ensureLoaded
INFO: Loading icon 'jar:file:/.../jmeter/lib/ext/darklaf-core.jar!/com/github/weisj/darklaf/icons/navigation/arrowDown.svg'.
```