### PR TITLE
Make armed state of a button visible for default and regular buttons

### DIFF
--- a/core/src/main/java/com/github/weisj/darklaf/ui/button/DarkButtonUI.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/button/DarkButtonUI.java
@@ -229,7 +229,7 @@ public class DarkButtonUI extends BasicButtonUI implements PropertyChangeListene
         boolean defaultButton = isDefaultButton(c);
         boolean rollOver = (c instanceof JButton && (((JButton) c).isRolloverEnabled()
                 && (((JButton) c).getModel().isRollover())));
-        boolean clicked = rollOver && ((JButton) c).getModel().isArmed();
+        boolean clicked = c instanceof JButton && ((JButton) c).getModel().isArmed();
         if (c.isEnabled()) {
             if (defaultButton) {
                 if (clicked) {

--- a/core/src/test/java/ui/button/ButtonDemo.java
+++ b/core/src/test/java/ui/button/ButtonDemo.java
@@ -43,7 +43,7 @@ public class ButtonDemo implements ComponentDemo {
         JButton button = new JButton("Test Button", icon);
         DemoPanel panel = new DemoPanel(button);
         JPanel controlPanel = panel.getControls();
-        controlPanel.setLayout(new GridLayout(5, 2));
+        controlPanel.setLayout(new GridLayout(6, 2));
         controlPanel.add(new JCheckBox("enabled") {{
             setSelected(button.isEnabled());
             addActionListener(e -> button.setEnabled(isSelected()));
@@ -96,6 +96,13 @@ public class ButtonDemo implements ComponentDemo {
                                                (b, c) -> button.putClientProperty("JButton.shadow.hover", b ? c : null)));
         controlPanel.add(new QuickColorChooser("JButton.shadow.click", Color.BLACK,
                                                (b, c) -> button.putClientProperty("JButton.shadow.click", b ? c : null)));
+        controlPanel.add(new JCheckBox("defaultButtonFollowsFocus") {{
+            setSelected(true);
+            addActionListener(e -> {
+                UIManager.put("Button.defaultButtonFollowsFocus", isSelected());
+                button.getRootPane().setDefaultButton(null);
+            });
+        }});
         return panel;
     }
 


### PR DESCRIPTION
Previously armed was painted only for rollover buttons