### PR TITLE
Add MigLayout for test code

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     implementation("org.swinglabs:jxlayer")
     compileOnly("org.swinglabs:swingx")
     testImplementation("com.formdev:svgSalamander")
+    testImplementation("com.miglayout:miglayout-core")
+    testImplementation("com.miglayout:miglayout-swing")
     testImplementation("org.swinglabs:swingx")
 }
 

--- a/core/src/test/java/ui/toolTip/ToolTipDemo.java
+++ b/core/src/test/java/ui/toolTip/ToolTipDemo.java
@@ -28,6 +28,7 @@ import com.github.weisj.darklaf.components.tooltip.ToolTipContext;
 import com.github.weisj.darklaf.components.tooltip.ToolTipStyle;
 import com.github.weisj.darklaf.components.tooltip.TooltipAwareButton;
 import com.github.weisj.darklaf.util.Alignment;
+import net.miginfocom.swing.MigLayout;
 import ui.ComponentDemo;
 import ui.DemoPanel;
 
@@ -48,13 +49,12 @@ public class ToolTipDemo implements ComponentDemo {
         button.setToolTipText("ToolTip demo text!");
 
         JPanel controlPanel = panel.getControls();
-        controlPanel.setLayout(new GridLayout(4, 2));
+        controlPanel.setLayout(new MigLayout("fillx, wrap 2", "[][grow]"));
 
-        controlPanel.add(new JLabel());
         controlPanel.add(new JCheckBox("Align inside") {{
             setSelected(context.isAlignInside());
             addActionListener(e -> context.setAlignInside(isSelected()));
-        }});
+        }}, "span");
         controlPanel.add(new JLabel("Tooltip Style:", JLabel.RIGHT));
         controlPanel.add(new JComboBox<ToolTipStyle>(ToolTipStyle.values()) {{
             setSelectedItem(ToolTipStyle.BALLOON);

--- a/dependencies-bom/build.gradle.kts
+++ b/dependencies-bom/build.gradle.kts
@@ -33,5 +33,7 @@ dependencies {
         apiv("org.swinglabs:jxlayer")
         apiv("org.swinglabs:swingx")
         apiv("com.formdev:svgSalamander")
+        apiv("com.miglayout:miglayout-core", "miglayout")
+        apiv("com.miglayout:miglayout-swing", "miglayout")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,6 @@ com.github.johnrengelman.shadow.version                   =5.1.0
 # Dependencies
 jna.version                                               =4.1.0
 jxlayer.version                                           =3.0.4
+miglayout.version                                         =5.2
 swingx.version                                            =1.6.1
 svgSalamander.version                                     =1.1.2.1


### PR DESCRIPTION
See http://miglayout.com/

Before:
<img width="727" alt="tooltipdemo_gridlayout" src="https://user-images.githubusercontent.com/213894/74836277-286d2a80-5330-11ea-8064-0a90d8fbee4a.png">

After:
<img width="471" alt="tooltipdemo_miglayout" src="https://user-images.githubusercontent.com/213894/74836289-302ccf00-5330-11ea-8c66-013bec2e72fc.png">

Even though demos are not complicated, MigLayout simplifies resize handling, and it does not require to count the number of cells and rows.

`wrap 2` means `wrap after each two components`.
`Align inside` spans the full row which is specified by `span`.

