### PR TITLE
Skip native library loading when darklaf.decorations=false

### DIFF
--- a/core/src/main/java/com/github/weisj/darklaf/platform/Decorations.java
+++ b/core/src/main/java/com/github/weisj/darklaf/platform/Decorations.java
@@ -42,14 +42,16 @@ public final class Decorations {
     static {
         try {
             //Extend for different platforms.
-            if (SystemInfo.isWindows) {
+            boolean enableDecorations =
+                !PropertyValue.FALSE.equals(System.getProperty(DarkLaf.SYSTEM_PROPERTY_PREFIX + "decorations"));
+            if (SystemInfo.isWindows && enableDecorations) {
                 decorationsProvider = new WindowsDecorationsProvider();
-            } else if (SystemInfo.isMac) {
+            } else if (SystemInfo.isMac && enableDecorations) {
                 decorationsProvider = new MacOSDecorationsProvider();
             } else {
                 decorationsProvider = new DefaultDecorationsProvider();
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             //If decorations modules are not available disable them.
             decorationsProvider = new DefaultDecorationsProvider();
         }
@@ -62,7 +64,6 @@ public final class Decorations {
 
     public static boolean isCustomDecorationSupported() {
         return decorationsProvider.isCustomDecorationSupported()
-            && !PropertyValue.FALSE.equals(System.getProperty(DarkLaf.SYSTEM_PROPERTY_PREFIX + "decorations"))
             && LafManager.isDecorationsEnabled()
             && LafManager.getTheme().useCustomDecorations();
     }

--- a/macos/src/main/java/com/github/weisj/darklaf/platform/macos/JNIDecorationsMacOS.java
+++ b/macos/src/main/java/com/github/weisj/darklaf/platform/macos/JNIDecorationsMacOS.java
@@ -81,7 +81,7 @@ public class JNIDecorationsMacOS {
                                    + SystemInfo.jreArchitecture
                                    + "' not supported. Decorations will be disabled");
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             //Library not found, SecurityManager prevents library loading etc.
             LOGGER.log(Level.SEVERE, "Could not load decorations library libdarklaf-macos.dylib." +
                 " Decorations will be disabled", e);

--- a/windows/src/main/java/com/github/weisj/darklaf/platform/windows/JNIDecorationsWindows.java
+++ b/windows/src/main/java/com/github/weisj/darklaf/platform/windows/JNIDecorationsWindows.java
@@ -81,7 +81,7 @@ public class JNIDecorationsWindows {
             }
             loaded = true;
             LOGGER.info("Loaded darklaf-windows.dll. Decorations are enabled.");
-        } catch (Exception e) {
+        } catch (Throwable e) {
             //Library not found, SecurityManager prevents library loading etc.
             LOGGER.log(Level.SEVERE, "Could not load decorations library darklaf-windows.dll." +
                 " Decorations will be disabled", e);


### PR DESCRIPTION
@weisJ , please merge & release darklaf.

fixes #73, #74