### PR TITLE
Fix non-ascii properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,6 +183,15 @@ allprojects {
                 options.encoding = "UTF-8"
             }
 
+            withType<ProcessResources>().configureEach {
+                from(source) {
+                    include("**/*.properties")
+                    filteringCharset = "UTF-8"
+                    // apply native2ascii conversion since Java 8 expects properties to have ascii symbols only
+                    filter(org.apache.tools.ant.filters.EscapeUnicode::class)
+                }
+            }
+
             withType<Jar>().configureEach {
                 manifest {
                     attributes["Bundle-License"] = "MIT"

--- a/core/src/main/resources/theme_settings_ru.properties
+++ b/core/src/main/resources/theme_settings_ru.properties
@@ -26,25 +26,25 @@ title                        = Настройки Темы
 color_default                = По умолчанию
 color_Blue                   = Синий
 color_lilac                  = Сирень
-color_rose                   = Rose
-color_red                    = Роза
-color_orange                 = Апельсин
-color_yellow                 = Желтый
-color_green                  = Зеленый
-color_gray                   = Графитовый
-color_custom                 = Изготовленный на заказ
+color_rose                   = Розовый
+color_red                    = Красный
+color_orange                 = Оранжевый
+color_yellow                 = Жёлтый
+color_green                  = Зелёный
+color_gray                   = Графит
+color_custom                 = Другой
 
 label_theme                  = Тема:
 
-label_accent_color           = Акцентный цвет:
-label_selection_color        = Выбор цвета:
+label_accent_color           = Цветовой акцент:
+label_selection_color        = Цвет выделения:
 
 label_font_size              = Размер шрифта:
 label_font_smaller           = Меньше
 label_font_default           = По умолчанию
 label_font_bigger            = Больше
 
-check_system_preferences     = Следуйте системным настройкам
+check_system_preferences     = Использовать настройки операционной системы
 check_system_accent_color    = Применить акцент цвет
 check_system_selection_color = Применить выделение цвета
 check_system_theme           = Применить тему
@@ -55,4 +55,4 @@ title_monitoring             = Система
 
 dialog_ok                    = ОК
 dialog_cancel                = Отмена
-dialog_apply                 = Применять
+dialog_apply                 = Применить


### PR DESCRIPTION
Java 8 expects that all non-ASCII characters should be excaped in *.properties