### PR TITLE
The super constructor of DarkScrollBarListener checks null animators

### DIFF
--- a/core/src/main/java/com/github/weisj/darklaf/ui/scrollpane/DarkScrollBarListener.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/scrollpane/DarkScrollBarListener.java
@@ -61,10 +61,10 @@ public class DarkScrollBarListener extends MouseAdapter implements AdjustmentLis
         trackFadeinAnimator = createTrackFadeinAnimator();
         thumbFadeoutAnimator = createThumbFadeoutAnimator();
         thumbFadeinAnimator = createThumbFadeinAnimator();
-        trackFadeoutAnimator.setEnabled(animationsEnabled);
-        trackFadeinAnimator.setEnabled(animationsEnabled);
-        thumbFadeoutAnimator.setEnabled(animationsEnabled);
-        thumbFadeinAnimator.setEnabled(animationsEnabled);
+        if (trackFadeoutAnimator != null) trackFadeoutAnimator.setEnabled(animationsEnabled);
+        if (trackFadeinAnimator != null) trackFadeinAnimator.setEnabled(animationsEnabled);
+        if (thumbFadeoutAnimator != null) thumbFadeoutAnimator.setEnabled(animationsEnabled);
+        if (thumbFadeinAnimator != null) thumbFadeinAnimator.setEnabled(animationsEnabled);
     }
 
     public void uninstall() {


### PR DESCRIPTION
solve NPE on macOS Java11: 
createTrackFadeinAnimator() and createTrackFadeoutAnimator() in MacScrollBarListener return null.
And those methods are called from the superclass DarkScrollBarListener, 
and the constructor calls setEnabled for the returned animators.
Just inserting null-checks for those call-sites seemed to solve the NPE.