### PR TITLE
Spanish translation correction

### DIFF
--- a/core/src/main/resources/com/github/weisj/darklaf/task/darklaf_es.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/task/darklaf_es.properties
@@ -28,12 +28,12 @@ Actions.cut                        = Cortar
 Actions.copy                       = Copiar
 Actions.paste                      = Pegar
 Actions.delete                     = Eliminar
-Actions.close                      = Cerca
+Actions.close                      = Cerrar
 Actions.maximize                   = Maximizar
 Actions.minimize                   = Minimizar
 Actions.restore                    = Restaurar
-Actions.closableTabbedPane.close   = Cerca. Alt-Click para cerrar otros
-Actions.save                       = Salvar
+Actions.closableTabbedPane.close   = Cerrar. Alt-Click para cerrar otros
+Actions.save                       = Guardar
 Actions.revert                     = Revertir
 Actions.predefinedValues           = Valores predefinidos
 

--- a/core/src/main/resources/com/github/weisj/darklaf/task/theme_settings_es.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/task/theme_settings_es.properties
@@ -28,14 +28,14 @@ settings.title                        = Configuración de Temas
 settings.color_default                = Defecto
 settings.color_blue                   = Azul
 settings.color_lilac                  = Lila
-settings.color_rose                   = Rosa
+settings.color_rose                   = Rosa vivo
 settings.color_red                    = Rojo
 settings.color_orange                 = Naranja
 settings.color_yellow                 = Amarillo
 settings.color_green                  = Verde
 settings.color_gray                   = Grafito
 settings.color_custom                 = Personalizado
-settings.color_purple                 = Lila
+settings.color_purple                 = Morado
 settings.color_pink                   = Rosa
 
 settings.label_theme                  = Tema:
@@ -43,12 +43,12 @@ settings.label_theme                  = Tema:
 settings.label_accent_color           = Color de acento
 settings.label_selection_color        = Color de selección
 
-settings.label_font_size              = Tamaño  de fuente
-settings.label_font_smaller           = Mas pequeño
+settings.label_font_size              = Tamaño de fuente
+settings.label_font_smaller           = Más pequeño
 settings.label_font_default           = Defecto
-settings.label_font_bigger            = Mas grande
+settings.label_font_bigger            = Más grande
 
-settings.check_system_preferences     = Siga las preferencias del sistema
+settings.check_system_preferences     = Seguir las preferencias del sistema
 settings.check_system_accent_color    = Aplicar color de acento
 settings.check_system_selection_color = Aplicar color de selección
 settings.check_system_theme           = Aplicar tema


### PR DESCRIPTION
I corrected the error that I mentioned on #269 plus a few others I found. If I may suggest something, maybe changing label_font_smaller to '-' and label_font_bigger to '+' would solve the overlapping issue while still being readable to the end user? Decided not to mess with it in case you have a better way of solving it.