### PR TITLE
Replace svgSalamander with JSVG

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ import com.github.vlsi.gradle.properties.dsl.toBool
 import com.github.vlsi.gradle.publishing.dsl.simplifyXml
 import com.github.vlsi.gradle.publishing.dsl.versionFromResolution
 import net.ltgt.gradle.errorprone.errorprone
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
     idea
@@ -217,6 +218,15 @@ allprojects {
         }
 
         tasks {
+            withType<Test>().configureEach {
+                testLogging {
+                    showStandardStreams = true
+                    showExceptions = true
+                    showStackTraces = true
+                    exceptionFormat = TestExceptionFormat.FULL
+                }
+            }
+
             withType<JavaCompile>().configureEach {
                 options.encoding = "UTF-8"
             }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(projects.darklafWindows)
     implementation(projects.darklafMacos)
     implementation(libs.swingDslLafSupport)
-    implementation(libs.svgSalamander)
+    implementation(libs.jsvg)
 
     compileOnly(libs.nullabilityAnnotations)
     compileOnly(libs.swingx)
@@ -27,7 +27,7 @@ dependencies {
     compileOnly(toolLibs.autoservice.annotations)
     annotationProcessor(toolLibs.autoservice.processor)
 
-    testImplementation(libs.svgSalamander)
+    testImplementation(libs.jsvg)
     testImplementation(libs.swingx)
     testImplementation(testLibs.bundles.miglayout)
     testImplementation(testLibs.swingDslInspector)

--- a/core/src/main/java/com/github/weisj/darklaf/LafInstaller.java
+++ b/core/src/main/java/com/github/weisj/darklaf/LafInstaller.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021 Jannis Weis
+ * Copyright (c) 2021-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -49,7 +49,7 @@ final class LafInstaller {
         try {
             LOGGER.fine(() -> "Installing theme " + theme);
             LafTransition transition = LafTransition.showSnapshot();
-            UIManager.setLookAndFeel(new DarkLaf(theme, false));
+            UIManager.setLookAndFeel(new DarkLaf(theme, false, true));
             updateLaf();
             SwingUtilities.invokeLater(transition::runTransition);
             notifyThemeInstalled(theme);

--- a/core/src/main/java/com/github/weisj/darklaf/components/ColoredRadioButton.java
+++ b/core/src/main/java/com/github/weisj/darklaf/components/ColoredRadioButton.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 Jannis Weis
+ * Copyright (c) 2020-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/core/src/main/java/com/github/weisj/darklaf/components/border/BubbleBorder.java
+++ b/core/src/main/java/com/github/weisj/darklaf/components/border/BubbleBorder.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021 Jannis Weis
+ * Copyright (c) 2019-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -270,29 +270,46 @@ public class BubbleBorder extends AbstractBorder {
         return getBorderInsets(c);
     }
 
+    public Shape[] getBubbleShapes(final float x, final float y, final float width, final float height,
+            final float adj) {
+        float w = width - 2 * adj;
+        float h = height - 2 * adj;
+        RoundRectangle2D.Float bubble = calculateBubbleRect(x + adj, y + adj, w, h);
+        final Shape[] shapes = new Shape[pointerSide != Alignment.CENTER ? 2 : 1];
+        shapes[0] = calculateBubbleRect(x + adj, y + adj, w, h);
+        if (pointerSide != Alignment.CENTER) {
+            shapes[1] = calculatePointerShape(adj, w, h, bubble);
+        }
+        return shapes;
+    }
+
+    private Shape calculatePointerShape(final float adj, final float w, final float h,
+            final RoundRectangle2D.Float bubble) {
+        double pSize = getPointerSize() - adj;
+        double pWidth = getPointerWidth() - 2 * adj;
+        double pointerPad = calculatePointerPad(w, h, pointerSide);
+        switch (pointerSide) {
+            case SOUTH_EAST:
+            case NORTH_EAST:
+                pointerPad += adj;
+                break;
+            case NORTH_WEST:
+            case SOUTH_WEST:
+                pointerPad -= adj;
+                break;
+            default:
+                break;
+        }
+        return creatPointerShape(pointerPad, pSize, pWidth, bubble);
+    }
+
     public Area getBubbleArea(final float x, final float y, final float width, final float height, final float adj) {
         float w = width - 2 * adj;
         float h = height - 2 * adj;
-        double pSize = getPointerSize() - adj;
-        double pWidth = getPointerWidth() - 2 * adj;
         RoundRectangle2D.Float bubble = calculateBubbleRect(x + adj, y + adj, w, h);
         final Area area = new Area(bubble);
         if (pointerSide != Alignment.CENTER) {
-            double pointerPad = calculatePointerPad(w, h, pointerSide);
-            switch (pointerSide) {
-                case SOUTH_EAST:
-                case NORTH_EAST:
-                    pointerPad += adj;
-                    break;
-                case NORTH_WEST:
-                case SOUTH_WEST:
-                    pointerPad -= adj;
-                    break;
-                default:
-                    break;
-            }
-            Path2D pointer = creatPointerShape(pointerPad, pSize, pWidth, bubble);
-            area.add(new Area(pointer));
+            area.add(new Area(calculatePointerShape(adj, w, h, bubble)));
         }
         return area;
     }

--- a/core/src/main/java/com/github/weisj/darklaf/components/color/PopupColorChooser.java
+++ b/core/src/main/java/com/github/weisj/darklaf/components/color/PopupColorChooser.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 Jannis Weis
+ * Copyright (c) 2020-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -49,6 +49,12 @@ public class PopupColorChooser extends JPanel implements ChooserComponent<Color>
         chooser = getChooser(initial, callback);
         add(chooser, BorderLayout.CENTER);
         setBackground(UIManager.getColor("ColorChooser.background"));
+    }
+
+    @Override
+    public void setBackground(Color bg) {
+        super.setBackground(bg);
+        if (chooser != null) chooser.setBackground(bg);
     }
 
     @Override

--- a/core/src/main/java/com/github/weisj/darklaf/components/color/SmallColorChooser.java
+++ b/core/src/main/java/com/github/weisj/darklaf/components/color/SmallColorChooser.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 Jannis Weis
+ * Copyright (c) 2020-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -194,8 +194,13 @@ public class SmallColorChooser extends JPanel implements ChooserComponent<Color>
         box.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
         previewComponent = createPreviewComponent();
 
-        JPanel hexFieldHolder = new JPanel(new GridBagLayout());
-        hexFieldHolder.setOpaque(false);
+        JPanel hexFieldHolder = new JPanel(new GridBagLayout()) {
+            @Override
+            public Color getBackground() {
+                return SmallColorChooser.this.getBackground();
+            }
+        };
+        hexFieldHolder.setOpaque(true);
         Box hexBox = Box.createHorizontalBox();
         JLabel label = new JLabel("#");
         hexBox.add(label);
@@ -285,11 +290,12 @@ public class SmallColorChooser extends JPanel implements ChooserComponent<Color>
 
             Descriptor label = new Descriptor(descriptors[i], descriptorsAfter[i],
                     model.getMinimum(i), model.getMaximum(i), slider::setValue);
-            label.setLabelFor(slider);
+            label.label.setLabelFor(slider);
 
             label.setBorder(BorderFactory.createEmptyBorder(0, LayoutHelper.getDefaultSpacing(), 0, 0));
             JPanel holder = new JPanel(new BorderLayout());
             holder.setOpaque(false);
+            holder.setBackground(Color.GREEN);
             holder.add(label, BorderLayout.BEFORE_FIRST_LINE);
             holder.add(slider, BorderLayout.CENTER);
             box.add(holder);
@@ -346,8 +352,7 @@ public class SmallColorChooser extends JPanel implements ChooserComponent<Color>
         };
     }
 
-    protected static class Descriptor extends JPanel {
-
+    protected class Descriptor extends JPanel {
 
         private final JFormattedTextField textField;
         private final JLabel label;
@@ -456,9 +461,13 @@ public class SmallColorChooser extends JPanel implements ChooserComponent<Color>
             });
             textField.setBorder(BorderFactory.createEmptyBorder());
             textField.setOpaque(false);
-            setOpaque(false);
             add(textField);
             setValue(min);
+        }
+
+        @Override
+        public Color getBackground() {
+            return SmallColorChooser.this.getBackground();
         }
 
         public void setValue(final Object value) {

--- a/core/src/main/java/com/github/weisj/darklaf/components/popup/AttachedPopupComponent.java
+++ b/core/src/main/java/com/github/weisj/darklaf/components/popup/AttachedPopupComponent.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 Jannis Weis
+ * Copyright (c) 2020-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -53,7 +53,12 @@ public class AttachedPopupComponent extends JToolTip {
         setLayout(new BorderLayout());
         this.content = content;
         add(content);
-        setBackground(content.getBackground());
+        content.setOpaque(false);
+    }
+
+    @Override
+    public Color getBackground() {
+        return content != null ? content.getBackground() : super.getBackground();
     }
 
     public static <K, T extends JComponent & ChooserComponent<K>> void attachChooser(final JComponent component,

--- a/core/src/main/java/com/github/weisj/darklaf/graphics/StringPainter.java
+++ b/core/src/main/java/com/github/weisj/darklaf/graphics/StringPainter.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 Jannis Weis
+ * Copyright (c) 2020-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -100,7 +100,11 @@ public final class StringPainter {
 
     public static <T extends JComponent> void drawStringImpl(final Graphics g, final T c, final View view,
             final String text, final Rectangle textRect, final Font font, final FontMetrics fm, final int mnemIndex) {
-        drawStringImpl(g, c, view, text, textRect, font, fm, mnemIndex, c.getBackground());
+        drawStringImpl(g, c, view, text, textRect, font, fm, mnemIndex, null);
+    }
+
+    private static Color effectiveBackgroundColor(JComponent c) {
+        return DarkUIUtil.getOpaqueParent(c).getBackground();
     }
 
     public static <T extends JComponent> void drawStringImpl(final Graphics g, final T c, final View view,
@@ -132,6 +136,9 @@ public final class StringPainter {
         boolean paintOpaqueBuffered = window != null;
 
         if (paintOpaqueBuffered) {
+            if (bgColor == null) {
+                bgColor = effectiveBackgroundColor(c);
+            }
             LOGGER.finest(() -> "Using opaque buffering for " + c);
             double scaleX = Scale.getScaleX((Graphics2D) g);
             double scaleY = Scale.getScaleX((Graphics2D) g);

--- a/core/src/main/java/com/github/weisj/darklaf/ui/internalframe/DarkInternalFrameBorder.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/internalframe/DarkInternalFrameBorder.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021 Jannis Weis
+ * Copyright (c) 2019-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -39,13 +39,9 @@ public class DarkInternalFrameBorder extends DropShadowBorder implements UIResou
         inactiveOpacity = UIManager.getInt("InternalFrame.inactiveShadowOpacity") / 100f;
         int shadowSize = UIManager.getInt("InternalFrame.shadowSize");
         setShadowSize(shadowSize);
-        setCornerSize(2 * shadowSize);
+        setCornerSize(shadowSize);
         setShadowOpacity(activeOpacity);
         setShadowColor(UIManager.getColor("InternalFrame.borderShadowColor"));
-        setShowTopShadow(true);
-        setShowBottomShadow(true);
-        setShowLeftShadow(true);
-        setShowRightShadow(true);
     }
 
     @Override

--- a/core/src/main/java/com/github/weisj/darklaf/ui/tooltip/DarkToolTipUI.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/tooltip/DarkToolTipUI.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021 Jannis Weis
+ * Copyright (c) 2019-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -22,7 +22,6 @@ package com.github.weisj.darklaf.ui.tooltip;
 
 import java.awt.*;
 import java.awt.event.*;
-import java.awt.geom.Area;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -43,7 +42,9 @@ import com.github.weisj.darklaf.util.PropertyKey;
 import com.github.weisj.darklaf.util.graphics.GraphicsContext;
 import com.github.weisj.darklaf.util.graphics.GraphicsUtil;
 
-/** @author Jannis Weis */
+/**
+ * @author Jannis Weis
+ */
 public class DarkToolTipUI extends BasicToolTipUI
         implements PropertyChangeListener, HierarchyListener, ToolTipConstants {
 
@@ -193,8 +194,10 @@ public class DarkToolTipUI extends BasicToolTipUI
         GraphicsContext context = GraphicsUtil.setupAntialiasing(g);
         g.setColor(c.getBackground());
         if (!isPlain && c.getBorder() instanceof DarkTooltipBorder) {
-            Area area = ((DarkTooltipBorder) c.getBorder()).getBackgroundArea(c, c.getWidth(), c.getHeight());
-            ((Graphics2D) g).fill(area);
+            for (Shape shape : ((DarkTooltipBorder) c.getBorder()).getBackgroundShapes(c, c.getWidth(),
+                    c.getHeight())) {
+                ((Graphics2D) g).fill(shape);
+            }
         } else {
             PaintUtil.fillRect(g, 0, 0, c.getWidth(), c.getHeight());
         }
@@ -280,9 +283,11 @@ public class DarkToolTipUI extends BasicToolTipUI
     public boolean contains(final JComponent c, final int x, final int y) {
         Border b = c.getBorder();
         if (b instanceof DarkTooltipBorder) {
-            Area insideArea =
-                    ((DarkTooltipBorder) b).getBackgroundArea(toolTip, toolTip.getWidth(), toolTip.getHeight());
-            return insideArea.contains(x, y);
+            for (Shape shape : ((DarkTooltipBorder) b).getBackgroundShapes(
+                    toolTip, toolTip.getWidth(), toolTip.getHeight())) {
+                if (shape.contains(x, y)) return true;
+            }
+            return false;
         } else {
             return super.contains(c, x, y);
         }

--- a/core/src/main/java/com/github/weisj/darklaf/ui/tooltip/DarkTooltipBorder.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/tooltip/DarkTooltipBorder.java
@@ -52,6 +52,8 @@ public class DarkTooltipBorder implements Border, AlignableTooltipBorder {
         bubbleBorder.setThickness(1);
         bubbleBorder.setPointerSize(8);
         bubbleBorder.setPointerWidth(12);
+        int borderRadius = UIManager.getInt("Tooltip.borderRadius");
+        bubbleBorder.setRadius(borderRadius);
         bubbleBorder.setPointerSide(Alignment.CENTER);
         int shadowSize = UIManager.getInt("ToolTip.shadowSize");
         float opacity = UIManager.getInt("ToolTip.shadowOpacity") / 100.0f;

--- a/core/src/main/java/com/github/weisj/darklaf/ui/tooltip/DarkTooltipBorder.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/tooltip/DarkTooltipBorder.java
@@ -60,13 +60,13 @@ public class DarkTooltipBorder implements Border, AlignableTooltipBorder {
         paintShadow = UIManager.getBoolean("ToolTip.paintShadow");
     }
 
-    public Area getBackgroundArea(final Component c, final int width, final int height) {
+    public Shape[] getBackgroundShapes(final Component c, final int width, final int height) {
         if (isPlain(c)) {
-            return new Area(new Rectangle(0, 0, width, height));
+            return new Area[] {new Area(new Rectangle(0, 0, width, height))};
         }
         Insets ins = shadowBorder.getBorderInsets(null);
         adjustInsets(ins);
-        return bubbleBorder.getBubbleArea(ins.left, ins.top, width - ins.left - ins.right,
+        return bubbleBorder.getBubbleShapes(ins.left, ins.top, width - ins.left - ins.right,
                 height - ins.top - ins.bottom, bubbleBorder.getThickness() / 3f);
     }
 

--- a/core/src/main/java/com/github/weisj/darklaf/ui/tooltip/DarkTooltipBorder.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/tooltip/DarkTooltipBorder.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021 Jannis Weis
+ * Copyright (c) 2019-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -55,8 +55,8 @@ public class DarkTooltipBorder implements Border, AlignableTooltipBorder {
         bubbleBorder.setPointerSide(Alignment.CENTER);
         int shadowSize = UIManager.getInt("ToolTip.shadowSize");
         float opacity = UIManager.getInt("ToolTip.shadowOpacity") / 100.0f;
-        shadowBorder = new DropShadowBorder(UIManager.getColor("ToolTip.borderShadowColor"), shadowSize, opacity,
-                2 * shadowSize, true, true, true, true);
+        Color shadowColor = UIManager.getColor("ToolTip.borderShadowColor");
+        shadowBorder = new DropShadowBorder(shadowColor, shadowSize, opacity, borderRadius);
         paintShadow = UIManager.getBoolean("ToolTip.paintShadow");
     }
 

--- a/core/src/main/resources/com/github/weisj/darklaf/platform/mac.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/platform/mac.properties
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2021 Jannis Weis
+# Copyright (c) 2019-2022 Jannis Weis
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,13 +30,14 @@ ScrollBar.macos.hideScrollBar            = false
 ScrollBar.macos.hideDelay                = 1200
 
 TooltipUI                                = com.github.weisj.darklaf.ui.tooltip.DarkMacTooltipUI
+Tooltip.borderRadius                     = 10
+ToolTip.paintShadow                      = false
 
 Table.alternateRowColor                  = true
 Tree.alternateRowColor                   = true
 List.alternateRowColor                   = true
 FileChooser.listViewWindowsStyle         = false
 PopupMenu.defaultLightWeightPopups       = false
-ToolTip.paintShadow                      = false
 
 InternalFrame.icon                       = navigation/arrow/thick/arrowDown.svg[themed]
 InternalFrame.useExternalMenuBar         = true

--- a/core/src/main/resources/com/github/weisj/darklaf/platform/windows11.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/platform/windows11.properties
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2021 Jannis Weis
+# Copyright (c) 2021-2022 Jannis Weis
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,3 +27,4 @@ ScrollBar.width                   = 12
 ScrollBar.minimumWidth            = 3
 ScrollBar.windows11.hideScrollBar = true
 ScrollBar.windows11.hideDelay     = 1200
+Tooltip.borderRadius              = 10

--- a/core/src/main/resources/com/github/weisj/darklaf/ui/toolTip.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/ui/toolTip.properties
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2021 Jannis Weis
+# Copyright (c) 2019-2022 Jannis Weis
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@ ToolTip.borderShadowColor  = %shadow
 ToolTip.paintShadow        = true
 ToolTip.shadowOpacity      = %shadowOpacityStrong
 ToolTip.shadowSize         = 12
+Tooltip.borderRadius       = 5
 ToolTip.borderInsets       = 5,10,5,10
 ToolTip.plainInsets        = 2,5,2,5
 ToolTip.defaultStyle       = plain

--- a/core/src/test/java/com/github/weisj/darklaf/core/test/DemoTest.java
+++ b/core/src/test/java/com/github/weisj/darklaf/core/test/DemoTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021 Jannis Weis
+ * Copyright (c) 2019-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -53,7 +53,6 @@ class DemoTest implements NonThreadSafeTest {
 
     @Test
     void runningDemosDoesNotThrow() {
-        @SuppressWarnings("Convert2MethodRef")
         Robot robot = Lambdas.orDefault(() -> new Robot(), null).get();
         LafManager.setLogLevel(Level.WARNING);
         for (Theme theme : LafManager.getRegisteredThemes()) {

--- a/core/src/test/java/com/github/weisj/darklaf/icon/AllIcons.java
+++ b/core/src/test/java/com/github/weisj/darklaf/icon/AllIcons.java
@@ -99,7 +99,7 @@ public class AllIcons extends BaseComponentDemo {
     protected static List<NamedIcon<? extends Icon>> loadIcons(final int displaySize, final boolean centered) {
         IconLoader loader = IconLoader.get();
         try (ResourceWalker walker = ResourceWalker.walkResources("com.github.weisj")) {
-            return walker.stream().filter(p -> p.endsWith("svg")).map(p -> {
+            return walker.stream().filter(p -> p.endsWith(".svg")).map(p -> {
                 ThemedSVGIcon icon = (ThemedSVGIcon) loader.loadSVGIcon(p, -displaySize, -displaySize, true);
                 return new NamedIcon<>(p, centered ? new CenterIcon(icon, displaySize, displaySize) : icon);
             }).collect(Collectors.groupingBy(pair -> pathToIconName(pair.getFirst())))

--- a/core/src/test/java/com/github/weisj/darklaf/icon/AllIcons.java
+++ b/core/src/test/java/com/github/weisj/darklaf/icon/AllIcons.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 Jannis Weis
+ * Copyright (c) 2020-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/core/src/test/java/com/github/weisj/darklaf/ui/DemoLauncher.java
+++ b/core/src/test/java/com/github/weisj/darklaf/ui/DemoLauncher.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 Jannis Weis
+ * Copyright (c) 2020-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import javax.swing.*;
 
+import com.github.weisj.darklaf.LafManager;
 import com.github.weisj.darklaf.core.test.DarklafOnly;
 import com.github.weisj.darklaf.core.test.DelicateDemo;
 import com.github.weisj.darklaf.core.test.util.ClassFinder;
@@ -90,14 +91,15 @@ public class DemoLauncher extends BaseComponentDemo {
             this.demo = demo;
         }
 
-        public AtomicReference<Window> start() {
-            return start(null).getFirst();
+        public void start() {
+            start(null);
         }
 
         public Pair<AtomicReference<Window>, ComponentDemo> start(final Level logLevel) {
             ComponentDemo componentDemo = demo.instantiate();
+            LafManager.setLogLevel(logLevel != null ? logLevel : Level.FINE);
             return new Pair<>(
-                    DemoExecutor.showDemo(componentDemo, true, logLevel),
+                    DemoExecutor.showDemoWithoutSetup(componentDemo, true),
                     componentDemo);
         }
 

--- a/core/src/test/java/com/github/weisj/darklaf/ui/demo/DemoExecutor.java
+++ b/core/src/test/java/com/github/weisj/darklaf/ui/demo/DemoExecutor.java
@@ -66,23 +66,28 @@ public final class DemoExecutor {
         DemoExecutionSpec executionSpec = demo.getExecutionSpec();
 
         SwingUtilities.invokeLater(() -> {
-            setupLaf(executionSpec);
-            Window window = createWindow(demo, asDialog);
-            executionSpec.configureWindow(window);
+            try {
+                setupLaf(executionSpec);
+                Window window = createWindow(demo, asDialog);
+                executionSpec.configureWindow(window);
 
-            Icon icon = executionSpec.getFrameIcon();
-            if (icon != null) {
-                window.setIconImage(IconLoader.createFrameIcon(icon, window));
-            }
+                Icon icon = executionSpec.getFrameIcon();
+                if (icon != null) {
+                    window.setIconImage(IconLoader.createFrameIcon(icon, window));
+                }
 
-            window.pack();
-            configureWindowSize(executionSpec, window);
+                window.pack();
+                configureWindowSize(executionSpec, window);
 
-            window.setVisible(true);
-            window.setLocationRelativeTo(null);
-            synchronized (windowRef) {
-                windowRef.set(window);
-                windowRef.notifyAll();
+                window.setVisible(true);
+                window.setLocationRelativeTo(null);
+                synchronized (windowRef) {
+                    windowRef.set(window);
+                }
+            } finally {
+                synchronized (windowRef) {
+                    windowRef.notifyAll();
+                }
             }
         });
         synchronized (windowRef) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ net.ltgt.errorprone.version                               = 2.0.2
 
 # Dependencies
 # Libraries
-svgSalamander.version                                     = 1.1.2.4
+jsvg.version                                              = 0.0.1
 swingDsl.version                                          = 0.1.3
 swingx.version                                            = 1.6.1
 nullabilityAnnotations.version                            = 23.0.0

--- a/property-loader/build.gradle.kts
+++ b/property-loader/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     api(projects.darklafUtils)
-    implementation(libs.svgSalamander)
+    implementation(libs.jsvg)
     implementation(libs.visualPaddings)
     compileOnly(libs.nullabilityAnnotations)
     compileOnly(toolLibs.errorprone.annotations)

--- a/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/CustomThemedIcon.java
+++ b/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/CustomThemedIcon.java
@@ -46,7 +46,7 @@ public class CustomThemedIcon extends ThemedSVGIcon implements MutableThemedIcon
 
     public CustomThemedIcon(final DarkSVGIcon icon, final Map<Object, Object> contextDefaults,
             final MergeMode mergeMode) {
-        super(icon.getUri(), icon.getIconWidth(), icon.getIconHeight());
+        super(icon.getURI(), icon.getIconWidth(), icon.getIconHeight());
         List<ThemedSVGIconParserProvider.ThemedSolidColorPaint> customPaints;
         if (icon instanceof ThemedSVGIcon) {
             icon.ensureLoaded(false);

--- a/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/DarkSVGIcon.java
+++ b/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/DarkSVGIcon.java
@@ -26,6 +26,7 @@ import java.awt.image.BufferedImage;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -147,6 +148,7 @@ public class DarkSVGIcon
             } catch (MalformedURLException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
+            Objects.requireNonNull(svgDocument, () -> "Document failed to load: " + iconUri.toASCIIString());
             loaded.set(true);
             return true;
         }

--- a/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/DarkSVGIconDomProcessor.java
+++ b/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/DarkSVGIconDomProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021-2022 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.github.weisj.darklaf.properties.icons;
+
+import java.awt.*;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.github.weisj.jsvg.parser.DomProcessor;
+import com.github.weisj.jsvg.parser.ParsedElement;
+
+public class DarkSVGIconDomProcessor<T extends DarkSVGIcon> implements DomProcessor {
+    protected final @NotNull T icon;
+
+    public DarkSVGIconDomProcessor(@NotNull T icon) {
+        this.icon = icon;
+    }
+
+    @Override
+    public void process(@NotNull ParsedElement root) {
+        float[] visualPaddings = root.attributeNode().getFloatList("visualPadding");
+        if (visualPaddings.length == 4) {
+            icon.setVisualPadding(new Insets(
+                    (int) visualPaddings[0],
+                    (int) visualPaddings[1],
+                    (int) visualPaddings[2],
+                    (int) visualPaddings[3]));
+        }
+    }
+}

--- a/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/IconColorMapper.java
+++ b/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/IconColorMapper.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021 Jannis Weis
+ * Copyright (c) 2019-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -22,24 +22,15 @@ package com.github.weisj.darklaf.properties.icons;
 
 import java.awt.*;
 import java.util.*;
-import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.swing.*;
 
 import com.github.weisj.darklaf.properties.PropertyLoader;
 import com.github.weisj.darklaf.properties.parser.ParseResult;
 import com.github.weisj.darklaf.properties.parser.Parser;
 import com.github.weisj.darklaf.properties.parser.ParserContext;
-import com.github.weisj.darklaf.util.ColorUtil;
 import com.github.weisj.darklaf.util.LogUtil;
 import com.github.weisj.darklaf.util.Pair;
 import com.github.weisj.darklaf.util.Types;
-import com.kitfox.svg.*;
-import com.kitfox.svg.animation.AnimationElement;
-import com.kitfox.svg.app.beans.SVGIcon;
-import com.kitfox.svg.xml.StyleAttribute;
 
 /**
  * Utility class responsible for patching color definitions in svg icons.
@@ -47,156 +38,23 @@ import com.kitfox.svg.xml.StyleAttribute;
  * @author Jannis Weis
  */
 public final class IconColorMapper {
-    private static final String INLINE_VALUE_PREFIX = "%";
     private static final Logger LOGGER = LogUtil.getLogger(IconLoader.class);
+    private static final String INLINE_VALUE_PREFIX = "%";
     private static final Color FALLBACK_COLOR = Color.RED;
 
-    public static void patchColors(final SVGIcon svgIcon) {
-        patchColors(svgIcon, UIManager.getDefaults());
-    }
-
-    public static void patchColors(final SVGIcon svgIcon, final Map<Object, Object> contextDefaults) {
-        patchColors(svgIcon, contextDefaults, null);
-    }
-
-    public static void patchColors(final SVGIcon svgIcon, final Map<Object, Object> defaults,
-            final Map<Object, Object> contextDefaults) {
-        SVGUniverse universe = svgIcon.getSvgUniverse();
-        SVGDiagram diagram = universe.getDiagram(svgIcon.getSvgURI());
-        LOGGER.finer(() -> "Patching colors of icon " + svgIcon.getSvgURI());
-        try {
-            loadColors(diagram, defaults, contextDefaults);
-        } catch (final SVGElementException e) {
-            LOGGER.log(Level.SEVERE, "Failed patching colors. " + e.getMessage(), e);
-        }
-    }
-
-    private static void loadColors(final SVGDiagram diagram, final Map<Object, Object> defaults,
-            final Map<Object, Object> contextDefaults)
-            throws SVGElementException {
-        SVGRoot root = diagram.getRoot();
-        SVGElement defs = diagram.getElement("colors");
-        if (defs == null) {
-            LOGGER.info(() -> {
-                String uri = diagram.getXMLBase().toASCIIString();
-                String name = uri.substring(Math.min(uri.lastIndexOf('/') + 1, uri.length() - 1));
-                return "Themed icon '" + name
-                        + "' has no color definitions. Consider loading it as a standard icon or add missing definitions";
-            });
-            return;
-        }
-        List<SVGElement> children = defs.getChildren(null);
-        root.removeChild(defs);
-
-        Defs themedDefs = new Defs();
-        themedDefs.addAttribute("id", AnimationElement.AT_XML, "colors");
-        root.loaderAddChild(null, themedDefs);
-
-        for (SVGElement child : children) {
-            if (child instanceof LinearGradient) {
-                LinearGradient grad = (LinearGradient) child;
-                String id = grad.getId();
-                StyleAttribute colorFallbacks = getAttribute("fallback", grad);
-                StyleAttribute opacityFallbacks = getAttribute("opacity-fallback", grad);
-                String opacityKey = getOpacityKey(grad);
-
-                float opacity = getOpacity(opacityKey, getFallbacks(opacityFallbacks), defaults, contextDefaults);
-                float opacity1 = opacity;
-                float opacity2 = opacity;
-                if (opacity < 0) {
-                    opacity = 1;
-                    int childCount = grad.getNumChildren();
-                    if (childCount > 0) {
-                        SVGElement elem = grad.getChild(0);
-                        if (elem instanceof Stop) {
-                            opacity1 = getStopOpacity((Stop) elem);
-                        }
-                    }
-                    if (childCount > 1) {
-                        SVGElement elem = grad.getChild(1);
-                        if (elem instanceof Stop) {
-                            opacity2 = getStopOpacity((Stop) elem);
-                        }
-                    }
-
-                    if (opacity1 < 0) opacity1 = opacity;
-                    if (opacity2 < 0) opacity2 = opacity;
-                }
-
-                Color c = resolveColor(id, getFallbacks(colorFallbacks), FALLBACK_COLOR, defaults, contextDefaults);
-                float finalOpacity1 = opacity1;
-                float finalOpacity2 = opacity2;
-                LOGGER.finest(() -> "Color: " + c + " opacity1: " + finalOpacity1 + " opacity2: " + finalOpacity2);
-                ColorResult result =
-                        createColor(c, id, opacityKey, new StyleAttribute[] {colorFallbacks, opacityFallbacks},
-                                finalOpacity2, opacity2);
-                themedDefs.loaderAddChild(null, result.gradient);
-                result.finalizer.run();
-                int resultRGB = ColorUtil.rgbNoAlpha(result.gradient.getStopColors()[0]);
-                int expectedRGB = ColorUtil.rgbNoAlpha(result.color);
-                if (expectedRGB != resultRGB) {
-                    throw new IllegalStateException("Color not applied. Expected " + result.color + " but received "
-                            + result.gradient.getStopColors()[0] + " (rgb " + expectedRGB + " != " + resultRGB + ")");
-                }
-                LOGGER.finest(() -> Arrays.toString(result.gradient.getStopColors()));
-            }
-        }
-        LOGGER.fine("Patching done");
-    }
-
-    public static float getOpacity(final LinearGradient gradient, final Map<Object, Object> propertyMap,
-            final Map<Object, Object> contextDefaults) {
-        String opacityKey = getOpacityKey(gradient);
-        return getOpacity(opacityKey, null, propertyMap, contextDefaults);
-    }
-
-    public static Color getColor(final LinearGradient gradient, final Map<Object, Object> propertyMap,
-            final Map<Object, Object> contextDefaults) {
-        String id = gradient.getId();
-        StyleAttribute fallbacks = getAttribute("fallback", gradient);
-        return resolveColor(id, getFallbacks(fallbacks), FALLBACK_COLOR, propertyMap, contextDefaults);
-    }
-
-    private static Color resolveColor(final String key, final String[] fallbacks, final Color fallbackColor,
+    public static Color resolveColor(final String key, final String[] fallbacks,
             final Map<Object, Object> propertyMap, final Map<Object, Object> contextDefaults) {
         Color color = get(propertyMap, contextDefaults, key, fallbacks, Color.class);
 
         if (color == null) {
-            color = fallbackColor;
+            color = FALLBACK_COLOR;
             LOGGER.warning("Could not load color with id '" + key + "' fallbacks" + Arrays.toString(fallbacks)
-                    + ". Using color '" + fallbackColor + "' instead.");
+                    + ". Using color '" + color + "' instead.");
         }
         return color;
     }
 
-    private static StyleAttribute getAttribute(final String key, final SVGElement child) {
-        StyleAttribute attribute = new StyleAttribute();
-        attribute.setName(key);
-        try {
-            child.getStyle(attribute);
-        } catch (final SVGException e) {
-            return null;
-        }
-        return attribute;
-    }
-
-    private static float getStopOpacity(final Stop stop) {
-        StyleAttribute attribute = new StyleAttribute();
-        attribute.setName("stop-opacity");
-        try {
-            stop.getStyle(attribute);
-        } catch (final SVGException e) {
-            return -1;
-        }
-        return !attribute.getStringValue().isEmpty() ? attribute.getFloatValue() : -1;
-    }
-
-    private static String[] getFallbacks(final StyleAttribute fallbacks) {
-        if (fallbacks == null) return new String[0];
-        return fallbacks.getStringList();
-    }
-
-    private static float getOpacity(final String key, final String[] fallbacks, final Map<Object, Object> propertyMap,
+    public static float getOpacity(final String key, final String[] fallbacks, final Map<Object, Object> propertyMap,
             final Map<Object, Object> contextDefaults) {
         if ((key == null || key.isEmpty()) && (fallbacks == null || fallbacks.length == 0)) return -1;
         // UIManager defaults to 0, if the value isn't an integer (or null).
@@ -213,124 +71,6 @@ public final class IconColorMapper {
         LOGGER.warning(obj + " is an invalid opacity value. Key = '" + key + "'");
         // In this case we default to -1.
         return -1;
-    }
-
-    private static String getOpacityKey(final LinearGradient child) {
-        StyleAttribute attribute = new StyleAttribute();
-        attribute.setName("opacity");
-        try {
-            child.getStyle(attribute);
-        } catch (final SVGException e) {
-            e.printStackTrace();
-            return null;
-        }
-        return attribute.getStringValue();
-    }
-
-    private static class ColorResult {
-        private final LinearGradient gradient;
-        private final Runnable finalizer;
-        private final Color color;
-
-        private ColorResult(LinearGradient gradient, Runnable finalizer, Color color) {
-            this.gradient = gradient;
-            this.finalizer = finalizer;
-            this.color = color;
-        }
-    }
-
-    private static ColorResult createColor(final Color c, final String name, final String opacityKey,
-            final StyleAttribute[] extraAttributes, final float opacity1, final float opacity2)
-            throws SVGElementException {
-        LinearGradient grad = new LinearGradient();
-        grad.addAttribute("id", AnimationElement.AT_XML, name);
-        if (opacityKey != null && !opacityKey.isEmpty()) {
-            grad.addAttribute("opacity", AnimationElement.AT_XML, opacityKey);
-        }
-        if (extraAttributes != null) {
-            for (StyleAttribute attribute : extraAttributes) {
-                if (attribute != null && !attribute.getStringValue().isEmpty()) {
-                    grad.addAttribute(attribute.getName(), AnimationElement.AT_XML, attribute.getStringValue());
-                }
-            }
-        }
-        return new ColorResult(grad, () -> {
-            String color = toHexString(c);
-            BuildableStop stop1 = new BuildableStop(color);
-            BuildableStop stop2 = new BuildableStop(color);
-            try {
-                stop1.addAttribute("stop-color", AnimationElement.AT_XML, color);
-                stop1.addAttribute("offset", AnimationElement.AT_XML, "0");
-                stop2.addAttribute("stop-color", AnimationElement.AT_XML, color);
-                stop2.addAttribute("offset", AnimationElement.AT_XML, "1");
-                if (opacity1 != 1) {
-                    stop1.addAttribute("stop-opacity", AnimationElement.AT_XML, String.valueOf(opacity1));
-                }
-                if (opacity2 != 1) {
-                    stop2.addAttribute("stop-opacity", AnimationElement.AT_XML, String.valueOf(opacity2));
-                }
-                grad.loaderAddChild(null, stop1);
-                grad.loaderAddChild(null, stop2);
-                stop1.build();
-                stop2.build();
-            } catch (final SVGException e) {
-                throw new RuntimeException(e);
-            }
-        }, ColorUtil.toAlpha(c, opacity1));
-    }
-
-    private static class BuildableStop extends Stop {
-
-        private final String color;
-
-        private BuildableStop(final String color) {
-            this.color = color;
-        }
-
-        @Override
-        public boolean getStyle(StyleAttribute attrib, boolean recursive, boolean evalAnimation) throws SVGException {
-            if ("stop-color".equals(attrib.getName())) {
-                attrib.setStringValue(color);
-                return true;
-            }
-            return super.getStyle(attrib, recursive, evalAnimation);
-        }
-
-        @Override
-        protected void build() throws SVGException {
-            super.build();
-        }
-    }
-
-    public static Map<Object, Object> getProperties(final SVGIcon svgIcon) {
-        SVGUniverse universe = svgIcon.getSvgUniverse();
-        SVGDiagram diagram = universe.getDiagram(svgIcon.getSvgURI());
-        SVGElement defs = diagram.getElement("colors");
-        Map<Object, Object> values = new HashMap<>();
-        if (defs != null) {
-            List<SVGElement> children = defs.getChildren(null);
-            for (SVGElement child : children) {
-                if (child instanceof LinearGradient) {
-                    LinearGradient grad = (LinearGradient) child;
-                    String colorKey = grad.getId();
-                    String opacityKey = getOpacityKey(grad);
-                    SVGElement c = grad.getChild(0);
-                    if (c instanceof Stop) {
-                        Stop stop = (Stop) c;
-                        StyleAttribute colorAttr = getAttribute("stop-color", stop);
-                        Color color = colorAttr != null ? colorAttr.getColorValue() : null;
-                        values.put(colorKey, color != null ? color : Color.BLACK);
-
-                        if (opacityKey != null && !opacityKey.isEmpty()) {
-                            StyleAttribute opacityAttr = getAttribute("stop-opacity", stop);
-                            int opacity = opacityAttr != null ? (int) (100 * opacityAttr.getFloatValue()) : 100;
-                            values.put(opacityKey, opacity);
-                        }
-                    }
-                }
-            }
-        }
-        return values;
     }
 
     public static <T> Pair<Object, T> getEntry(final Map<Object, Object> map, final Map<Object, Object> contextDefaults,
@@ -366,7 +106,7 @@ public final class IconColorMapper {
                         // We found the value
                         break outer;
                     } else {
-                        // Further search won't find anything.
+                        // Any further searches won't find anything.
                         // The value doesn't explicitly reference other keys.
                         continue outer;
                     }
@@ -380,9 +120,5 @@ public final class IconColorMapper {
     public static <T> T get(final Map<Object, Object> map, final Map<Object, Object> contextDefaults, final Object key,
             final Object[] fallbacks, final Class<T> type) {
         return getEntry(map, contextDefaults, key, fallbacks, type).getSecond();
-    }
-
-    private static String toHexString(final Color color) {
-        return "#" + ColorUtil.toHex(color);
     }
 }

--- a/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/ThemedSVGIconParserProvider.java
+++ b/property-loader/src/main/java/com/github/weisj/darklaf/properties/icons/ThemedSVGIconParserProvider.java
@@ -1,0 +1,158 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021-2022 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.github.weisj.darklaf.properties.icons;
+
+import java.awt.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.github.weisj.darklaf.util.ColorUtil;
+import com.github.weisj.jsvg.attributes.paint.DefaultPaintParser;
+import com.github.weisj.jsvg.attributes.paint.SimplePaintSVGPaint;
+import com.github.weisj.jsvg.nodes.Defs;
+import com.github.weisj.jsvg.nodes.LinearGradient;
+import com.github.weisj.jsvg.parser.AttributeNode;
+import com.github.weisj.jsvg.parser.DefaultParserProvider;
+import com.github.weisj.jsvg.parser.DomProcessor;
+import com.github.weisj.jsvg.parser.ParsedElement;
+
+public class ThemedSVGIconParserProvider extends DefaultParserProvider {
+    private final DomProcessor preProcessor;
+
+    public ThemedSVGIconParserProvider(final @NotNull ThemedSVGIcon icon) {
+        preProcessor = new ThemedSVGIconDomProcessor(icon);
+    }
+
+    @Override
+    public @Nullable DomProcessor createPreProcessor() {
+        return preProcessor;
+    }
+
+    private static class ThemedSVGIconDomProcessor extends DarkSVGIconDomProcessor<ThemedSVGIcon> {
+
+        public ThemedSVGIconDomProcessor(@NotNull ThemedSVGIcon icon) {
+            super(icon);
+        }
+
+        @Override
+        public void process(final @NotNull ParsedElement root) {
+            super.process(root);
+            for (ParsedElement child : root.children()) {
+                if ("colors".equals(child.id()) && child.node() instanceof Defs) {
+                    replaceGradients(child);
+                    return;
+                }
+            }
+        }
+
+        private void replaceGradients(final ParsedElement element) {
+            for (ParsedElement child : element.children()) {
+                if (child.node() instanceof LinearGradient) {
+                    replaceSingleGradient(child);
+                }
+            }
+        }
+
+        private void replaceSingleGradient(final ParsedElement gradient) {
+            String id = gradient.id();
+            if (id == null) return;
+
+            AttributeNode attributeNode = gradient.attributeNode();
+            String[] fallbacks = attributeNode.getStringList("fallback");
+            String opacityKey = attributeNode.getValue("opacity");
+            String[] opacityFallback = attributeNode.getStringList("opacity-fallback");
+
+            List<ParsedElement> stops = gradient.children();
+            float originalOpacity = 1;
+            if (!stops.isEmpty()) {
+                originalOpacity = stops.get(0).attributeNode().getPercentage("stop-opacity", originalOpacity);
+            }
+
+            ThemedSVGIconParserProvider.ThemedSolidColorPaint themedPaint =
+                    new ThemedSVGIconParserProvider.ThemedSolidColorPaint(
+                            id, fallbacks, opacityKey, opacityFallback, originalOpacity);
+            gradient.registerNamedElement(id, themedPaint);
+            icon.registerPaint(themedPaint);
+        }
+    }
+
+    public static void patchColors(final List<ThemedSolidColorPaint> paints, final Map<Object, Object> propertyMap,
+            final Map<Object, Object> contextDefaults) {
+        for (ThemedSolidColorPaint paint : paints) {
+            paint.color = IconColorMapper.resolveColor(
+                    paint.colorKey, paint.colorFallbacks, propertyMap, contextDefaults);
+            float opacity = IconColorMapper.getOpacity(
+                    paint.opacityKey, paint.opacityFallbacks, propertyMap, contextDefaults);
+            if (opacity < 0) opacity = paint.originalOpacity;
+            paint.color = ColorUtil.toAlpha(paint.color, opacity);
+        }
+    }
+
+    public static Map<Object, Object> getProperties(List<ThemedSVGIconParserProvider.ThemedSolidColorPaint> paints) {
+        Map<Object, Object> values = new HashMap<>(paints.size() * 2, 0.75f);
+        for (ThemedSVGIconParserProvider.ThemedSolidColorPaint paint : paints) {
+            values.put(paint.colorKey, ColorUtil.removeAlpha(paint.color));
+            if (paint.opacityKey != null && !paint.opacityKey.isEmpty()) {
+                values.put(paint.opacityKey, (int) (paint.color.getAlpha() / 255f));
+            }
+        }
+        return values;
+    }
+
+    public static Map<String, Color> getNamedColors(final ThemedSVGIcon icon) {
+        icon.ensureLoaded(false);
+        return icon.paints().stream().collect(Collectors.toMap(
+                p -> p.colorKey,
+                p -> p.color));
+    }
+
+    static class ThemedSolidColorPaint implements SimplePaintSVGPaint {
+
+        private final String colorKey;
+        private final String[] colorFallbacks;
+        private final String opacityKey;
+        private final String[] opacityFallbacks;
+
+        private final float originalOpacity;
+
+        private Color color = DefaultPaintParser.DEFAULT_COLOR;
+
+        ThemedSolidColorPaint(final String colorKey, final String[] colorFallbacks,
+                final String opacityKey, final String[] opacityFallbacks,
+                float originalOpacity) {
+            this.colorKey = colorKey;
+            this.colorFallbacks = colorFallbacks;
+            this.opacityKey = opacityKey;
+            this.opacityFallbacks = opacityFallbacks;
+            this.originalOpacity = originalOpacity;
+        }
+
+        @Override
+        public @NotNull Paint paint() {
+            return color;
+        }
+    }
+}

--- a/property-loader/src/main/module/module-info.java
+++ b/property-loader/src/main/module/module-info.java
@@ -26,7 +26,7 @@ module darklaf.properties {
     requires transitive java.desktop;
     requires transitive darklaf.utils;
     requires swingdsl.visualPadding;
-    requires com.kitfox.svg;
+    requires com.github.weisj.jsvg;
 
     requires static org.jetbrains.annotations;
 

--- a/property-loader/src/test/java/com/github/weisj/darklaf/properties/icons/SVGImageTest.java
+++ b/property-loader/src/test/java/com/github/weisj/darklaf/properties/icons/SVGImageTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021 Jannis Weis
+ * Copyright (c) 2019-2022 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import com.kitfox.svg.app.beans.SVGIcon;
+import com.github.weisj.jsvg.SVGDocument;
 
 @ResourceLock(value = "IconLoader")
 class SVGImageTest {
@@ -45,8 +45,8 @@ class SVGImageTest {
         DarkSVGIcon icon = (DarkSVGIcon) loader.getIcon("svg_icon.svg", 16, 16);
         Assertions.assertSame(icon, icon.derive(16, 16));
 
-        // Force load the icon.
-        icon.getSVGIcon();
+        // Forcefully load the icon.
+        icon.getSVGDocument();
 
         icon.setDisplaySize(-1, -1);
         Assertions.assertSame(icon, loader.getIcon("svg_icon.svg", 16, 16));
@@ -62,7 +62,7 @@ class SVGImageTest {
         Assertions.assertSame(icon, loader.getIcon("svg_icon.svg", 16, 16));
 
         // Force load
-        icon.getSVGIcon();
+        icon.getSVGDocument();
         Assertions.assertSame(icon, loader.getIcon("svg_icon.svg", 16, 16));
 
         icon.setDisplaySize(50, 50);
@@ -70,8 +70,8 @@ class SVGImageTest {
 
         icon.setDisplaySize(-1, -1);
         Assertions.assertNotSame(icon, loader.getIcon("svg_icon.svg", 50, 50));
-        Assertions.assertSame(icon.getSVGIcon(),
-                ((DarkSVGIcon) loader.getIcon("svg_icon.svg", 50, 50)).getSVGIcon());
+        Assertions.assertSame(icon.getSVGDocument(),
+                ((DarkSVGIcon) loader.getIcon("svg_icon.svg", 50, 50)).getSVGDocument());
 
 
         Assertions.assertEquals(16, icon.getIconWidth());
@@ -86,17 +86,17 @@ class SVGImageTest {
         Assertions.assertEquals(16, icon.getIconWidth());
         Assertions.assertEquals(16, icon.getIconHeight());
 
-        Set<SVGIcon> svgSet = new HashSet<>();
+        Set<SVGDocument> svgSet = new HashSet<>();
         for (int i = 0; i < 100; i++) {
             DarkSVGIcon svgIcon = (DarkSVGIcon) loader.getIcon("svg_icon.svg");
-            svgSet.add(svgIcon.getSVGIcon());
+            svgSet.add(svgIcon.getSVGDocument());
         }
         Assertions.assertEquals(1, svgSet.size());
 
         svgSet.clear();
         for (int i = 0; i < 100; i++) {
             DarkSVGIcon icon2 = icon.derive(i, i);
-            svgSet.add(icon2.getSVGIcon());
+            svgSet.add(icon2.getSVGDocument());
         }
         Assertions.assertEquals(1, svgSet.size());
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
         }
 
         create("libs") {
-            idv("svgSalamander", "com.formdev:svgSalamander")
+            idv("jsvg", "com.github.weisj:jsvg")
             idv("swingDslLafSupport", "com.github.weisj:swing-extensions-laf-support", "swingDsl")
             idv("visualPaddings", "com.github.weisj:swing-extensions-visual-padding", "swingDsl")
             idv("swingx", "org.swinglabs:swingx")


### PR DESCRIPTION
Currently svgSalamander is used to implement svg icons. For the purposes of only rendering the svg images without any dom manipulation or other runtime changes to the document graph we can replace it with the lightweight implementation [JSVG](https://www.github.com/weisj/jsvg).