### PR TITLE
Correct Chinese and Japanese translations

### DIFF
--- a/core/src/main/resources/com/github/weisj/darklaf/task/darklaf_ja.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/task/darklaf_ja.properties
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2021 Jannis Weis
+# Copyright (c) 2019-2022 Jannis Weis
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,19 +21,19 @@
 # SOFTWARE.
 #
 # suppress inspection "UnusedProperty" for whole file
-Actions.cut                        = 切る
-Actions.copy                       = 写し
-Actions.paste                      = 貼付
-Actions.delete                     = 削除する
+Actions.cut                        = 切り取り
+Actions.copy                       = コピー
+Actions.paste                      = 貼り付け
+Actions.delete                     = 削除
 Actions.close                      = 閉じる
 Actions.maximize                   = 最大化
 Actions.minimize                   = 最小化
-Actions.restore                    = 戻す
-Actions.closableTabbedPane.close   = 閉じる。 Alt-クリックして他を閉じる
-Actions.save                       = セーブ
+Actions.restore                    = 元のサイズに戻す
+Actions.closableTabbedPane.close   = 閉じる。Alt キーを押しながらクリックすると、この夕ブ以外の他の夕ブを閉じます。
+Actions.save                       = 保存する
 Actions.revert                     = 元に戻す
 Actions.predefinedValues           = 事前定義された値
 
-Labels.colorChooser                = カラーチューザー
+Labels.colorChooser                = カラーピッカー
 
 ColorChooser.wheel.textAndMnemonic = カラーホイール

--- a/core/src/main/resources/com/github/weisj/darklaf/task/darklaf_zh.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/task/darklaf_zh.properties
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2021 Jannis Weis
+# Copyright (c) 2019-2022 Jannis Weis
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,17 +21,17 @@
 # SOFTWARE.
 #
 # suppress inspection "UnusedProperty" for whole file
-Actions.cut                        = 切
+Actions.cut                        = 剪切
 Actions.copy                       = 复制
-Actions.paste                      = 糊
+Actions.paste                      = 粘贴
 Actions.delete                     = 删除
-Actions.close                      = 关
+Actions.close                      = 关闭
 Actions.maximize                   = 最大化
 Actions.minimize                   = 最小化
-Actions.restore                    = 恢复
-Actions.closableTabbedPane.close   = 关。 Alt单击以关闭其他人
-Actions.save                       = 救
-Actions.revert                     = 还原
+Actions.restore                    = 还原
+Actions.closableTabbedPane.close   = 关闭。按 Alt 并点击以关闭其他。
+Actions.save                       = 保存
+Actions.revert                     = 撤销
 Actions.predefinedValues           = 预定义值
 
 Labels.colorChooser                = 颜色选择器

--- a/core/src/main/resources/com/github/weisj/darklaf/task/tabFrame_ja.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/task/tabFrame_ja.properties
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2021 Jannis Weis
+# Copyright (c) 2019-2022 Jannis Weis
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,12 +21,12 @@
 # SOFTWARE.
 #
 # suppress inspection "UnusedProperty" for whole file
-popup.moveTo            = へ引っ越す
+popup.moveTo            = 移動
 popup.moveTo.north      = 上 左
-popup.moveTo.south      = 未満 正しい
-popup.moveTo.east       = 正しい 上
-popup.moveTo.west       = 左 未満
-popup.moveTo.north_east = 上 正しい
+popup.moveTo.south      = 下 右
+popup.moveTo.east       = 右 上
+popup.moveTo.west       = 左 下
+popup.moveTo.north_east = 上 右
 popup.moveTo.north_west = 左 上
-popup.moveTo.south_east = 正しい 未満
-popup.moveTo.south_west = 未満 左
+popup.moveTo.south_east = 右 下
+popup.moveTo.south_west = 下 左

--- a/core/src/main/resources/com/github/weisj/darklaf/task/tabFrame_zh.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/task/tabFrame_zh.properties
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2021 Jannis Weis
+# Copyright (c) 2019-2022 Jannis Weis
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,12 +21,12 @@
 # SOFTWARE.
 #
 # suppress inspection "UnusedProperty" for whole file
-popup.moveTo            = 搬去
-popup.moveTo.north      = 以上 剩下
-popup.moveTo.south      = 下面 对
-popup.moveTo.east       = 对 以上
-popup.moveTo.west       = 剩下 下面
-popup.moveTo.north_east = 以上 对
-popup.moveTo.north_west = 剩下 以上
-popup.moveTo.south_east = 对 下面
-popup.moveTo.south_west = 下面 剩下
+popup.moveTo            = 移至
+popup.moveTo.north      = 顶部 左侧
+popup.moveTo.south      = 底部 右侧
+popup.moveTo.east       = 右侧 顶部
+popup.moveTo.west       = 左侧 底部
+popup.moveTo.north_east = 顶部 右侧
+popup.moveTo.north_west = 左侧 顶部
+popup.moveTo.south_east = 右侧 底部
+popup.moveTo.south_west = 底部 左侧

--- a/core/src/main/resources/com/github/weisj/darklaf/task/theme_settings_ja.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/task/theme_settings_ja.properties
@@ -1,0 +1,59 @@
+# MIT License
+#
+# Copyright (c) 2019-2022 Jannis Weis
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# suppress inspection "UnusedProperty" for whole file
+settings.title                        = テーマ設定
+settings.color_default                = ディフォルト
+settings.color_blue                   = 青色
+settings.color_lilac                  = 深紫色
+settings.color_rose                   = バラ色
+settings.color_red                    = 赤色
+settings.color_orange                 = オレンジ色
+settings.color_yellow                 = 黄色
+settings.color_green                  = 緑色
+settings.color_gray                   = 灰色
+settings.color_custom                 = カスタマイズ
+settings.color_purple                 = 紫色
+settings.color_pink                   = 桜色
+
+settings.label_theme                  = テーマ
+
+settings.label_accent_color           = アクセント色
+settings.label_selection_color        = ハイライト色
+
+settings.label_font_size              = フォントサイズ
+settings.label_font_smaller           = 小さい
+settings.label_font_default           = ディフォルト
+settings.label_font_bigger            = 大きい
+
+settings.check_system_preferences     = システム環境設定に従う
+settings.check_system_accent_color    = アクセント色を適用する
+settings.check_system_selection_color = ハイライト色を適用する
+settings.check_system_theme           = テーマを適用する
+settings.check_system_font            = フォントサイズを適用する
+
+settings.title_general                = 一般
+settings.title_monitoring             = システム
+
+settings.dialog_ok                    = OK
+settings.dialog_cancel                = キャンセル
+settings.dialog_apply                 = 適用

--- a/core/src/main/resources/com/github/weisj/darklaf/task/theme_settings_zh.properties
+++ b/core/src/main/resources/com/github/weisj/darklaf/task/theme_settings_zh.properties
@@ -1,0 +1,59 @@
+# MIT License
+#
+# Copyright (c) 2019-2022 Jannis Weis
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# suppress inspection "UnusedProperty" for whole file
+settings.title                        = 主题设置
+settings.color_default                = 默认
+settings.color_blue                   = 蓝色
+settings.color_lilac                  = 深紫色
+settings.color_rose                   = 玫红色
+settings.color_red                    = 红色
+settings.color_orange                 = 橙色
+settings.color_yellow                 = 黄色
+settings.color_green                  = 绿色
+settings.color_gray                   = 灰色
+settings.color_custom                 = 自定义
+settings.color_purple                 = 紫色
+settings.color_pink                   = 粉红色
+
+settings.label_theme                  = 主题
+
+settings.label_accent_color           = 强调色
+settings.label_selection_color        = 选择色
+
+settings.label_font_size              = 字体大小
+settings.label_font_smaller           = 更小
+settings.label_font_default           = 默认
+settings.label_font_bigger            = 更大
+
+settings.check_system_preferences     = 跟随系统偏好设置
+settings.check_system_accent_color    = 应用强调色
+settings.check_system_selection_color = 应用选择色
+settings.check_system_theme           = 应用主题
+settings.check_system_font            = 应用字体大小
+
+settings.title_general                = 常规
+settings.title_monitoring             = 系统
+
+settings.dialog_ok                    = 确定
+settings.dialog_cancel                = 取消
+settings.dialog_apply                 = 应用


### PR DESCRIPTION
Thank you for making such a fantastic Swing Look and Feel! I corrected some Chinese and Japanese translation errors. 

Btw, I cannot find the Chinese and Japanese translation files of `theme_settings.properties`. Is it to copy the original files directly and rename the new ones to `_zh` and `_ja`? If so, please tell me, don't merge the pull request for now, I will translate them too.

Thank you!