### PR TITLE
Usage sample with the Nokee version management plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,22 +1,17 @@
-apply(from= "../gradle/loadProps.gradle.kts")
-
 plugins {
     `kotlin-dsl`
     `java-gradle-plugin`
 }
 
-val nokeeVersion = extra["nokee.version"]
-
 dependencies {
-    implementation(platform("dev.nokee:nokee-gradle-plugins:$nokeeVersion"))
+    implementation(nokeeApi())
     implementation(gradleApi())
 }
 
 repositories {
     mavenCentral()
     gradlePluginPortal()
-    maven { url = uri("https://repo.nokee.dev/release") }
-    maven { url = uri("https://repo.nokee.dev/snapshot") }
+    nokee()
 }
 
 gradlePlugin {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("dev.nokee.nokee-version-management")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,10 @@ pluginManagement {
     }
 }
 
+plugins {
+  id("dev.nokee.nokee-version-management") version("1.0.0")
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         fun VersionCatalogBuilder.idv(name: String, coordinates: String, versionRef: String = name) {


### PR DESCRIPTION
This PR is strictly for feedback. We are almost ready to release the `nokee-version-management` plugin which has the goal of simplifying the integration of Nokee with Gradle. For this specific project, the benefits are hiding the complexity of choosing the right repository to declare (based on the version used), the Nokee API coordinate is now opaque and handled by a single method `nokeeApi()` and the Nokee version in use was moved to a single location which both the main build and `buildSrc` uses.

The management plugin also accepts the `NOKEE_VERSION` environment variable as an override to try other Nokee versions without editing the code (the repositories will also point to the correct snapshot vs release repo).

I can see that you have your own method for managing plugin versions, so any feedback regarding this change is welcome. I want to keep the version management as simple as possible. We could pick a fourth location (e.g. System/Gradle properties), `nokee.version` could be a reasonable name to look for. Your suggestion and thought is more than welcome.