### PR TITLE
Check for leftover temporary files

### DIFF
--- a/native-utils/src/main/java/com/github/weisj/darklaf/nativeutil/NativeUtil.java
+++ b/native-utils/src/main/java/com/github/weisj/darklaf/nativeutil/NativeUtil.java
@@ -145,6 +145,7 @@ public final class NativeUtil {
         Path tempDir = getTemporaryDirectory();
         Path temp = tempDir.resolve(filename);
 
+        deleteLeftoverTempFiles();
         extractFile(loaderClass, path, tempDir, temp);
 
         try {
@@ -167,6 +168,27 @@ public final class NativeUtil {
         } catch (final IOException e) {
             delete(destinationPath);
             throw e;
+        }
+    }
+
+    private static void deleteLeftoverTempFiles()  {
+        deleteFolder(new File(System.getProperty("java.io.tmpdir")));
+    }
+
+    /**
+     * Recursively deletes a folder and it's files
+     * @param folder the target folder as {@link File}
+     */
+    private static void deleteFolder(File folder) {
+        File[] files = folder.listFiles((dir, name) -> name.startsWith(NATIVE_FOLDER_PATH_PREFIX));
+        if (files != null) { // File#listFiles might be null if empty
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    deleteFolder(file);
+                } else {
+                    delete(file.toPath());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Especially on Windows, leftover temp files are an issue, as files are locked and cannot be deleted, until unloaded by the JVM. 

Because manually unloading `System.load`-ed dynamic libraries is pretty complicated, this band-aid solution just deletes past temporary files. One ~180kiB DLL isn't a big deal imo, potentially hundreds or even thousands of them piling up is.

For demonstration, I launched an app that uses darklaf 10 times. 
![2022-07-31_15-05](https://user-images.githubusercontent.com/17730120/182028204-4c767cf2-4af9-48b9-9afe-2448fbfa474d.png)


fixes #325 