### PR TITLE
[#344] Fire change when opacity has changed

### DIFF
--- a/core/src/main/java/com/github/weisj/darklaf/ui/colorchooser/ColorTriangle.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/colorchooser/ColorTriangle.java
@@ -262,8 +262,9 @@ public class ColorTriangle extends JComponent {
         return opacity;
     }
 
-    public void setOpacity(final double opacity) {
+    public void setOpacity(final Object source, final double opacity) {
         this.opacity = opacity;
+        fireColorChanged(source);
     }
 
     public int[] getValuesForModel(final DarkColorModel model) {

--- a/core/src/main/java/com/github/weisj/darklaf/ui/colorchooser/ColorWheelPanel.java
+++ b/core/src/main/java/com/github/weisj/darklaf/ui/colorchooser/ColorWheelPanel.java
@@ -49,7 +49,7 @@ public class ColorWheelPanel extends JPanel {
             opacitySlider.setToolTipText("Opacity");
             opacitySlider.setUnits(opacityInPercent ? SlideComponent.Unit.PERCENT : SlideComponent.Unit.LEVEL);
             opacitySlider.addListener(integer -> {
-                colorWheel.setOpacity(integer / 255.0);
+                colorWheel.setOpacity(opacitySlider, integer / 255.0);
                 ColorWheelPanel.this.repaint();
             });
             add(opacitySlider, BorderLayout.SOUTH);


### PR DESCRIPTION
This PR fixes #344. When setting the opacity in `ColorTriangle.java`, `fireColorChanged` is called which updates the color with the new opacity.

Works great now in my application:

https://github.com/weisJ/darklaf/assets/11031519/b9f2c61f-1ac1-45a8-8ed1-eb199cec6052

